### PR TITLE
fix: gateway health config discovery + agent model object crash

### DIFF
--- a/lib/demo-fixtures.ts
+++ b/lib/demo-fixtures.ts
@@ -211,7 +211,7 @@ export const gatewayHealth = {
   configPath: {
     path: "/home/user/.openclaw/openclaw.json",
     source: "command" as const,
-    command: "openclaw config path",
+    command: "openclaw config file",
   },
 };
 

--- a/pages/api/gateway-health.ts
+++ b/pages/api/gateway-health.ts
@@ -53,8 +53,8 @@ async function runCommand(cmd: string, args: string[]) {
 }
 
 async function resolveConfigPath() {
-  const attempted = "openclaw config path";
-  const jsonResult = await runCommand("openclaw", ["config", "path", "--json"]);
+  const attempted = "openclaw config file";
+  const jsonResult = await runCommand("openclaw", ["config", "file", "--json"]);
   if (jsonResult.stdout) {
     try {
       const parsed = JSON.parse(jsonResult.stdout);
@@ -67,7 +67,7 @@ async function resolveConfigPath() {
     }
   }
 
-  const plainResult = await runCommand("openclaw", ["config", "path"]);
+  const plainResult = await runCommand("openclaw", ["config", "file"]);
   if (plainResult.stdout) {
     const firstLine = plainResult.stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
     if (firstLine) {

--- a/pages/api/oc-agents.ts
+++ b/pages/api/oc-agents.ts
@@ -52,7 +52,8 @@ async function handler(
           const id = a.id;
           const workspace = a.workspace || (id === "main" ? defaultWorkspace : join(HOME, `.openclaw/workspace-${id}`));
           const agentDir = a.agentDir || join(HOME, `.openclaw/agents/${id}/agent`);
-          const model = a.model || defaultModel;
+          const rawModel = a.model || defaultModel;
+          const model = typeof rawModel === "object" && rawModel !== null ? (rawModel.primary || "unknown") : String(rawModel);
           const skillCount = Array.isArray(a.skills) ? a.skills.length : 0;
 
           let sessionCount = 0;


### PR DESCRIPTION
## Summary

Two small bug fixes:

- **Gateway Health widget** (`config path` → `config file`): The health API called `openclaw config path` which doesn't exist in the OpenClaw CLI. The correct subcommand is `openclaw config file`. This caused the widget to always show "command discovery failed". Fixes #3.

- **Agents API model object handling**: When an agent defines its model as an object (`{"primary": "..."}`) instead of a string, the object was passed through to the response and React crashed with error #31. Now extracts the `primary` field from model objects. Fixes #2.

## Test plan

- [ ] Gateway Health widget shows probe results instead of "Probe status unavailable"
- [ ] `/agents` page renders without crash when agents use object-style model config